### PR TITLE
Removed trailing white space at the end of the result from get.

### DIFF
--- a/mayonnaise.js
+++ b/mayonnaise.js
@@ -115,7 +115,10 @@ mayonnaise.prototype.get = function(number) {
     if (!number) return 'Is mayonnaise an instrument?';
     var string = '';
     for (var i = 0; i < number; i++) {
-        string += quotes[Math.floor(Math.random() * quotes.length)] + ' ';
+      string += quotes[Math.floor(Math.random() * quotes.length)];
+      if (i != number-1) {
+        string += ' ';
+      }
     }
     return string;
 };


### PR DESCRIPTION
All calls to get, that were being given a number of quotes to return, ended with a trailing white space. This has now been removed.
